### PR TITLE
Fix panic when regex is not valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Notes:
 Below is an example of a VersionTracker resource:
 
 ```yaml
-apiVersion: vt.skillz.com/v1alpha1
+apiVersion: opvic.skillz.com/v1alpha1
 kind: VersionTracker
 metadata:
   name: myApp # name of the subject

--- a/agent/extract_version.go
+++ b/agent/extract_version.go
@@ -62,8 +62,8 @@ func (r *VersionTrackerReconciler) ExtractSubjectVersion(v v1alpha1.VersionTrack
 			continue
 		}
 		fieldValue := valueStrings[0]
-		version = GetResultsFromRegex(lv.Extraction.Regex.Pattern, lv.Extraction.Regex.Result, fieldValue)
-		if version == "" {
+		version, err = utils.GetResultsFromRegex(lv.Extraction.Regex.Pattern, lv.Extraction.Regex.Result, fieldValue)
+		if err != nil || version == "" {
 			log.Error(fmt.Errorf("failed to extract version from: %s", fieldValue), "extraction failed", "regex", lv.Extraction.Regex.Pattern, "result template", lv.Extraction.Regex.Result)
 			reconciliationErrorsTotal.Inc()
 			continue

--- a/agent/extract_version.go
+++ b/agent/extract_version.go
@@ -63,7 +63,12 @@ func (r *VersionTrackerReconciler) ExtractSubjectVersion(v v1alpha1.VersionTrack
 		}
 		fieldValue := valueStrings[0]
 		version, err = utils.GetResultsFromRegex(lv.Extraction.Regex.Pattern, lv.Extraction.Regex.Result, fieldValue)
-		if err != nil || version == "" {
+		if err != nil {
+			log.Error(fmt.Errorf("failed to extract version from: %s", fieldValue), "invalid regex", "regex", lv.Extraction.Regex.Pattern, "result template", lv.Extraction.Regex.Result)
+			reconciliationErrorsTotal.Inc()
+			continue
+		}
+		if version == "" {
 			log.Error(fmt.Errorf("failed to extract version from: %s", fieldValue), "extraction failed", "regex", lv.Extraction.Regex.Pattern, "result template", lv.Extraction.Regex.Result)
 			reconciliationErrorsTotal.Inc()
 			continue

--- a/agent/utils.go
+++ b/agent/utils.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"regexp"
 
 	"k8s.io/client-go/util/jsonpath"
 	"k8s.io/kubectl/pkg/cmd/get"
@@ -28,11 +27,4 @@ func getFeilds(jsonPath string, resource interface{}) ([]string, error) {
 		}
 	}
 	return valueStrings, nil
-}
-
-func GetResultsFromRegex(pattern, tmpl, content string) string {
-	regex := regexp.MustCompile(pattern)
-	matches := regex.FindStringSubmatchIndex(content)
-	result := regex.ExpandString([]byte{}, tmpl, content, matches)
-	return string(result)
 }

--- a/controlplane/providers/github/github.go
+++ b/controlplane/providers/github/github.go
@@ -185,7 +185,10 @@ func (p *Provider) getVersionsFromReleases(conf v1alpha1.RemoteVersion) ([]strin
 		if release.GetTagName() == "" {
 			continue
 		}
-		matched, v := utils.MatchPattern(conf.Extraction.Regex.Pattern, conf.Extraction.Regex.Result, release.GetName())
+		matched, v, err := utils.MatchPattern(conf.Extraction.Regex.Pattern, conf.Extraction.Regex.Result, release.GetName())
+		if err != nil {
+			return nil, err
+		}
 		if matched {
 			matchedVersions = append(matchedVersions, v)
 		}
@@ -217,7 +220,10 @@ func (p *Provider) getVersionsFromTags(conf v1alpha1.RemoteVersion) ([]string, e
 		if tag.GetName() == "" {
 			continue
 		}
-		matched, v := utils.MatchPattern(conf.Extraction.Regex.Pattern, conf.Extraction.Regex.Result, tag.GetName())
+		matched, v, err := utils.MatchPattern(conf.Extraction.Regex.Pattern, conf.Extraction.Regex.Result, tag.GetName())
+		if err != nil {
+			return nil, err
+		}
 		if matched {
 			matchedVersions = append(matchedVersions, v)
 		}

--- a/controlplane/providers/helm/helm.go
+++ b/controlplane/providers/helm/helm.go
@@ -111,7 +111,10 @@ func (p *Provider) GetVersions(conf v1alpha1.RemoteVersion) ([]string, error) {
 		} else if conf.Strategy == v1alpha1.HelmStrategyAppVersion {
 			version = chartVersion.AppVersion
 		}
-		matched, v := utils.MatchPattern(conf.Extraction.Regex.Pattern, conf.Extraction.Regex.Result, version)
+		matched, v, err := utils.MatchPattern(conf.Extraction.Regex.Pattern, conf.Extraction.Regex.Result, version)
+		if err != nil {
+			return nil, err
+		}
 		if matched {
 			matchedVersions = append(matchedVersions, v)
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,19 +7,25 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-func GetResultsFromRegex(pattern, tmpl, content string) string {
+func GetResultsFromRegex(pattern, tmpl, content string) (string, error) {
 	if pattern == "" || tmpl == "" {
-		return content
+		return content, nil
 	}
-	regex := regexp.MustCompile(pattern)
+	regex, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", err
+	}
 	matches := regex.FindStringSubmatchIndex(content)
 	result := regex.ExpandString([]byte{}, tmpl, content, matches)
-	return string(result)
+	return string(result), nil
 }
 
-func MatchPattern(pattern, tmpl, version string) (bool, string) {
-	result := GetResultsFromRegex(pattern, tmpl, version)
-	return result != "", result
+func MatchPattern(pattern, tmpl, version string) (bool, string, error) {
+	result, err := GetResultsFromRegex(pattern, tmpl, version)
+	if err != nil {
+		return false, "", err
+	}
+	return result != "", result, nil
 }
 
 func MeetConstraint(constraint, ver string) (bool, error) {


### PR DESCRIPTION
Agent or control plane should not panic if the regex is wrong, instead we should just log the error and move on.