### PR TITLE
(fix): Kube-score in helm lint job CI Workflow

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -39,7 +39,7 @@ jobs:
           chmod 755 kube-score
 
       - name: Kube-score generated manifests
-        run: helm template --values charts/opvic/ci/values-kube-score.yaml charts/* | ./kube-score score -
+        run: helm template --values charts/opvic/ci/kube-score-values.yaml charts/* | ./kube-score score -
               --ignore-test pod-networkpolicy
               --ignore-test deployment-has-poddisruptionbudget
               --ignore-test deployment-has-host-podantiaffinity


### PR DESCRIPTION
Before: `Error: open charts/opvic/ci/values-kube-score.yaml: no such file or directory`

Expected:
<img width="1356" alt="image" src="https://user-images.githubusercontent.com/18074432/157474764-470fe602-8167-466d-86c7-fe9bbd3a6434.png">
